### PR TITLE
Version2 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ const serverManagerCouchdb = await managerCouchdb.getServerManager("localhost:59
 const dbManagerCouchdb = await managerCouchdb.getDatabaseManager("localhost:5984", "databasename")
 ```
 
+
+## How to test it
+Checkout project with git and run `test/testAll` and `test/testDesign` node scripts. 
+Check `SERVER_URL` and `DB_NAME` settings if they fit to your environment.
+   
 ### Server manager
 ```
 var serverRunning = await serverManagerCouchdb.isServerRunning()
@@ -28,7 +33,8 @@ var resCreateDb = await serverManagerCouchdb.createDatabase("databasename")
 ```
 
 ### Database manager
-```var dbInformation = dbManagerCouchdb.getDatabaseInformation()
+```
+var dbInformation = await dbManagerCouchdb.getDatabaseInformation()
 
 var resInsertDoc = await dbManagerCouchdb.insertDocument(document)
 
@@ -36,13 +42,42 @@ var resDestroyDoc = await dbManagerCouchdb.destroyDocument(documentId, revisionI
 
 var resInsertDocsBulk = await dbManagerCouchdb.insertDocumentInBulk(documents)
 
-var document = dbManagerCouchdb.getDocument(documentId)
+var document = await dbManagerCouchdb.getDocument(documentId)
 
-var viewResults = dbManagerCouchdb.getView(designName, viewName, keys)
+var viewResults = await dbManagerCouchdb.getView(designName, viewName, keys)
 
-var viewResultsMultQueries = dbManagerCouchdb.getViewWithMuktipleQueries(designName, viewName, arrayKeys)
+var resView = await  dbManagerCouchdb.getViewWithQuery(designName,viewName, queryParams,includeDocs);
+
+var design = await dbManagerCouchdb.getDesign()
+
+var resFetch= await dbManagerCouchdb.fetchDocumentsInBulk(toBeFetched);
+
+var resDel = await dbManagerCouchdb.deleteDocumentInBulk({"docs":arrayOfDocIds});
+
 
 ```
 
+## What's new in Version 2.0
+
+
+Dependencies:
+ - removed package `request-promise-native` from dependencies (package was blocking  upgrade of `nano` to version > 8.2.3)
+ - upgraded `nano` to version `10.0.0`   
+
+
+Added db document functions:
+  - `getDesign` for getting all design and view documents,
+  - `deleteDocumentsInBulk` for deleting array of documents, 
+  - `fetchDocumentsInBulk` for fetching array of documents,
+  - `getViewWithQuery` for getting view with different key options
+ 
+Removed db document functions:
+  - `getViewWithMultipleQueries`: not needed anymore, replaced partially by `getViewWithQuery`
+  
+Modified db document functions:
+ - `destroyDocument`: revision parameter is optional,
+
+Tests:
+  - added test for Node (no testing framework is required)
 
 

--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
-var serverManager = require('./serverManager')
-var databaseManager = require('./databaseManager')
+const serverManager = require('./serverManager');
+const databaseManager = require('./databaseManager');
 
 module.exports.getServerManager = async (serverUrl) => {
   return await serverManager.getServerManager(serverUrl)
-}
+};
 
 module.exports.getDatabaseManager = async (serverUrl, databaseName) => {
   return await databaseManager.getDatabaseManager(serverUrl, databaseName)
-}
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,466 +1,142 @@
 {
   "name": "managercouchdb",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@types/caseless": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.1.tgz",
-      "integrity": "sha512-FhlMa34NHp9K5MY1Uz8yb+ZvuX0pnvn3jScRSNAb75KHGB8d3rEU6hqMs3Z2vjuytcMfRg6c5CHMc3wtYyD2/A=="
-    },
-    "@types/form-data": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.2.1.tgz",
-      "integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
-      "requires": {
-        "@types/node": "10.12.2"
-      }
-    },
-    "@types/node": {
-      "version": "10.12.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.2.tgz",
-      "integrity": "sha512-53ElVDSnZeFUUFIYzI8WLQ25IhWzb6vbddNp8UHlXQyU0ET2RhV5zg0NfubzU7iNMh5bBXb0htCzfvrSVNgzaQ=="
-    },
-    "@types/request": {
-      "version": "2.48.1",
-      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.1.tgz",
-      "integrity": "sha512-ZgEZ1TiD+KGA9LiAAPPJL68Id2UWfeSO62ijSXZjFJArVV+2pKcsVHmrcu+1oiE3q6eDGiFiSolRc4JHoerBBg==",
-      "requires": {
-        "@types/caseless": "0.12.1",
-        "@types/form-data": "2.2.1",
-        "@types/node": "10.12.2",
-        "@types/tough-cookie": "2.3.4"
-      }
-    },
     "@types/tough-cookie": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.4.tgz",
-      "integrity": "sha512-Set5ZdrAaKI/qHdFlVMgm/GsAv/wkXhSTuZFkJ+JI7HK+wIkIlOaUXSXieIvJ0+OvGIqtREFoE+NHJtEq0gtEw=="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.2.tgz",
+      "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw=="
     },
-    "ajv": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+    "axios": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
       "requires": {
-        "co": "4.6.0",
-        "fast-deep-equal": "1.1.0",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.3.1"
+        "follow-redirects": "^1.14.8"
       }
     },
-    "asn1": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+    "axios-cookiejar-support": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/axios-cookiejar-support/-/axios-cookiejar-support-1.0.1.tgz",
+      "integrity": "sha512-IZJxnAJ99XxiLqNeMOqrPbfR7fRyIfaoSLdPUf4AMQEGkH8URs0ghJK/xtqBsD+KsSr3pKl4DEQjCn834pHMig==",
       "requires": {
-        "safer-buffer": "2.1.2"
+        "is-redirect": "^1.0.0",
+        "pify": "^5.0.0"
       }
     },
-    "assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-    },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-    },
-    "aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
-    },
-    "aws4": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
-    },
-    "bcrypt-pbkdf": {
+    "call-bind": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
       "requires": {
-        "tweetnacl": "0.14.5"
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
       }
     },
-    "browser-request": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/browser-request/-/browser-request-0.3.3.tgz",
-      "integrity": "sha1-ns5bWsqJopkyJC4Yv5M975h2zBc="
+    "follow-redirects": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
+      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA=="
     },
-    "caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
-    "cloudant-follow": {
-      "version": "0.17.0",
-      "resolved": "http://registry.npmjs.org/cloudant-follow/-/cloudant-follow-0.17.0.tgz",
-      "integrity": "sha512-JQ1xvKAHh8rsnSVBjATLCjz/vQw1sWBGadxr2H69yFMwD7hShUGDwwEefdypaxroUJ/w6t1cSwilp/hRUxEW8w==",
+    "get-intrinsic": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
+      "integrity": "sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==",
       "requires": {
-        "browser-request": "0.3.3",
-        "debug": "3.2.6",
-        "request": "2.88.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "requires": {
-            "ms": "2.1.1"
-          }
-        }
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.3"
       }
     },
-    "co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
-    },
-    "combined-stream": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
-      "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "requires": {
-        "delayed-stream": "1.0.0"
+        "function-bind": "^1.1.1"
       }
     },
-    "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    "has-symbols": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
     },
-    "dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "requires": {
-        "assert-plus": "1.0.0"
-      }
-    },
-    "debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "requires": {
-        "ms": "2.0.0"
-      },
-      "dependencies": {
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        }
-      }
-    },
-    "delayed-stream": {
+    "is-redirect": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-    },
-    "ecc-jsbn": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-      "requires": {
-        "jsbn": "0.1.1",
-        "safer-buffer": "2.1.2"
-      }
-    },
-    "errs": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/errs/-/errs-0.3.2.tgz",
-      "integrity": "sha1-eYCZstvTfKK8dJ5TinwTB9C1BJk="
-    },
-    "extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-    },
-    "extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
-    },
-    "fast-deep-equal": {
-      "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
-    },
-    "fast-json-stable-stringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
-    },
-    "forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
-    },
-    "form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.7",
-        "mime-types": "2.1.21"
-      }
-    },
-    "getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "requires": {
-        "assert-plus": "1.0.0"
-      }
-    },
-    "har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
-    },
-    "har-validator": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
-      "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
-      "requires": {
-        "ajv": "5.5.2",
-        "har-schema": "2.0.0"
-      }
-    },
-    "http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.15.2"
-      }
-    },
-    "is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-    },
-    "isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
-    },
-    "jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
-    },
-    "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
-    },
-    "json-schema-traverse": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
-    },
-    "json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-    },
-    "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "requires": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
-        "verror": "1.10.0"
-      }
-    },
-    "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
-    },
-    "lodash.isempty": {
-      "version": "4.4.0",
-      "resolved": "http://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
-      "integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4="
-    },
-    "mime-db": {
-      "version": "1.37.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
-      "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg=="
-    },
-    "mime-types": {
-      "version": "2.1.21",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
-      "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
-      "requires": {
-        "mime-db": "1.37.0"
-      }
-    },
-    "ms": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+      "integrity": "sha512-cr/SlUEe5zOGmzvj9bUyC4LVvkNVAXu4GytXLNMr1pny+a65MpQ9IJzFHD5vi7FyJgb4qt27+eS3TuQnqB+RQw=="
     },
     "nano": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/nano/-/nano-7.1.0.tgz",
-      "integrity": "sha512-wDmmuUbCnqTykpStLYf46/rn4at6qMNsV7DeMks/jQmhHJUm9q/k4kar7c34CkHnMpLLIoT12+XmKWofTudNCQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/nano/-/nano-10.0.0.tgz",
+      "integrity": "sha512-evvi6NpUkFlqT1hKxj6YZ2vaQwVWvL1/v/hbqrApDSG0ZE/fSsuzlIxr9pd9JlhkrwI+zw4RDIsitaOYTC94YQ==",
       "requires": {
-        "@types/request": "2.48.1",
-        "cloudant-follow": "0.17.0",
-        "debug": "2.6.9",
-        "errs": "0.3.2",
-        "lodash.isempty": "4.4.0",
-        "request": "2.88.0"
+        "@types/tough-cookie": "^4.0.0",
+        "axios": "^0.26.1",
+        "axios-cookiejar-support": "^1.0.1",
+        "qs": "^6.10.3",
+        "tough-cookie": "^4.0.0"
       }
     },
-    "oauth-sign": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+    "object-inspect": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
+      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ=="
     },
-    "performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    "pify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-5.0.0.tgz",
+      "integrity": "sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA=="
     },
     "psl": {
-      "version": "1.1.29",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-      "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
     },
     "punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "qs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
-    },
-    "request": {
-      "version": "2.88.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+      "version": "6.10.5",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.5.tgz",
+      "integrity": "sha512-O5RlPh0VFtR78y79rgcgKK4wbAI0C5zGVLztOIdpWX6ep368q5Hv6XRxDvXuZ9q3C6v+e3n8UfZZJw7IIG27eQ==",
       "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.8.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.7",
-        "extend": "3.0.2",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.3",
-        "har-validator": "5.1.0",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.21",
-        "oauth-sign": "0.9.0",
-        "performance-now": "2.1.0",
-        "qs": "6.5.2",
-        "safe-buffer": "5.1.2",
-        "tough-cookie": "2.4.3",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.3.2"
+        "side-channel": "^1.0.4"
       }
     },
-    "request-promise-core": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
-      "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+    "side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
       "requires": {
-        "lodash": "4.17.11"
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
       }
-    },
-    "request-promise-native": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
-      "integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
-      "requires": {
-        "request-promise-core": "1.1.1",
-        "stealthy-require": "1.1.1",
-        "tough-cookie": "2.4.3"
-      }
-    },
-    "safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-    },
-    "safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
-    "sshpk": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.2.tgz",
-      "integrity": "sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA==",
-      "requires": {
-        "asn1": "0.2.4",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.2",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.2",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "safer-buffer": "2.1.2",
-        "tweetnacl": "0.14.5"
-      }
-    },
-    "stealthy-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
     },
     "tough-cookie": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
+      "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
       "requires": {
-        "psl": "1.1.29",
-        "punycode": "1.4.1"
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.1.2"
       }
     },
-    "tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "requires": {
-        "safe-buffer": "5.1.2"
-      }
-    },
-    "tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
-    },
-    "uuid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
-    },
-    "verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "requires": {
-        "assert-plus": "1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
-      }
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "managercouchdb",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "Manager for CouchdDB servers and databases",
   "main": "index.js",
   "scripts": {
@@ -20,7 +20,6 @@
   },
   "homepage": "https://github.com/SPINEProject/ManagerCouchdb#readme",
   "dependencies": {
-    "nano": "^7.1.0",
-    "request-promise-native": "^1.0.5"
+    "nano": "10.0.0"
   }
 }

--- a/serverManager.js
+++ b/serverManager.js
@@ -1,12 +1,10 @@
-var rp = require('request-promise-native');
-
 
 module.exports.getServerManager = async (serverUrl) => {
 
   // Variable to be returned
-  var serverManagerCouchdb = {}
+  const serverManagerCouchdb = {};
   
-  let nano = require('nano')(serverUrl)
+  let nano = require('nano')(serverUrl);
 
   /**
    * Function that checks if the server is reachable
@@ -14,15 +12,10 @@ module.exports.getServerManager = async (serverUrl) => {
    * @rejects {Promise<string>} if an error occurs in the request
    */
   serverManagerCouchdb.isServerRunning = async () => {
-    return new Promise( async (resolve, reject) => {
-
-      let options = {
-        uri: serverUrl,
-        method: 'GET'
-      };
+    return new Promise( async (resolve) => {
 
       try {
-        await rp(options)
+        await nano.info();
         resolve(true)
       }
       catch(err){
@@ -30,7 +23,7 @@ module.exports.getServerManager = async (serverUrl) => {
       }
 
     })
-  }
+  };
 
   /**
    * Function that returns the server information
@@ -40,13 +33,8 @@ module.exports.getServerManager = async (serverUrl) => {
   serverManagerCouchdb.getServerInformation = async () => {
     return new Promise( async (resolve, reject) => {
 
-      let options = {
-        uri: serverUrl,
-        method: 'GET'
-      };
-
       try {
-        let serverInformation = await rp(options)
+        let serverInformation = await nano.info();
         resolve(serverInformation)
       }
       catch(err){
@@ -54,28 +42,23 @@ module.exports.getServerManager = async (serverUrl) => {
       }
 
     })
-  }
+  };
 
   /**
    * Function that checks if a database exists in the couchdb server
-   * @param {string} serverUrl is the url of the server
    * @resolves {bool} true if the database exists, false otherwise
    * @rejects {Promise<string>} if the server is not reachable
+   * @param databaseName
    */
   serverManagerCouchdb.databaseExist = async (databaseName) => {
     return new Promise( async (resolve, reject) => {
 
-      let isServerUp = await serverManagerCouchdb.isServerRunning()
+      let isServerUp = await serverManagerCouchdb.isServerRunning();
       if( !isServerUp )
-        reject("The server is not reachable.")
-
-      let options = {
-        uri: serverUrl + '/' + databaseName,
-        method: 'GET'
-      };
+        reject("The server is not reachable.");
 
       try {
-        await rp(options)
+        await nano.db.get(databaseName);
         resolve(true)
       }
       catch(err){
@@ -83,7 +66,7 @@ module.exports.getServerManager = async (serverUrl) => {
       }
 
     })
-  }
+  };
 
   /**
    * Function that creates a database in the couchdb server
@@ -95,20 +78,20 @@ module.exports.getServerManager = async (serverUrl) => {
   serverManagerCouchdb.createDatabase = async (databaseName) => {
     return new Promise( async (resolve, reject) => {
 
-      let isServerUp = await serverManagerCouchdb.isServerRunning()
+      let isServerUp = await serverManagerCouchdb.isServerRunning();
       if( !isServerUp )
-        reject("The server is not reachable.")
+        reject("The server is not reachable.");
 
-      nano.db.create(databaseName, function (err, body) {
+      await nano.db.create(databaseName, function (err, body) {
         if (!err) {
-          resolve(body)
+          resolve(true)
         }
         else
           reject('Error creating database ' + databaseName + '. Error: ' + err)
       });
 
     })
-  }
+  };
 
   /**
    * Function that destroys a database in the couchdb server
@@ -120,11 +103,11 @@ module.exports.getServerManager = async (serverUrl) => {
   serverManagerCouchdb.destroyDatabase = async(databaseName) => {
     return new Promise( async (resolve, reject) => {
 
-      let isServerUp = await serverManagerCouchdb.isServerRunning()
+      let isServerUp = await serverManagerCouchdb.isServerRunning();
       if( !isServerUp )
-        reject("The server is not reachable.")
+        reject("The server is not reachable.");
 
-      nano.db.destroy(databaseName, function(err, body){
+      await nano.db.destroy(databaseName, function(err, body){
         if(!err){
           resolve(true)
         }
@@ -135,8 +118,8 @@ module.exports.getServerManager = async (serverUrl) => {
       });
 
     })
-  }
+  };
 
   return serverManagerCouchdb
 
-}
+};

--- a/test/testAll.js
+++ b/test/testAll.js
@@ -1,0 +1,182 @@
+'use strict';
+
+const SERVER_URL = "http://localhost:5984";
+const DB_NAME = "testing"; // do not use production DB -  just create a testing one!!!
+
+
+const TESTING_DOCS = [
+  {"docType": "test", "value":1},
+  {"docType": "test", "value":2},
+  {"docType": "test", "value":3},
+  {"docType": "test", "value":1},
+  ];
+
+/**
+ * No need to use JEST here! it can be tested with Node process only!
+ *
+ * @returns {boolean} true if the process was executed, false otherwise
+ * @throws {string} if an error occurred during the process
+ */
+const main = async () => {
+
+  let reqResult = null;
+  let condition = null;
+  const testResult = ()=>{
+    if (condition) return "PASSED";
+    return "FAILED";
+  };
+  try {
+    const dbManager = require("../databaseManager");
+    const sManager = require("../serverManager");
+
+    const serverManager = await sManager.getServerManager(SERVER_URL);
+
+
+    // ----- server manager -----
+    // --- isServerRunning ---
+    if (!await serverManager.isServerRunning())
+      return;
+
+    // --- getServerInformation ---
+    reqResult = await serverManager.getServerInformation();
+    console.log("Server: ", reqResult);
+
+
+    console.log("=============Server manager tests============= ");
+    // server exist
+    condition = reqResult!=null &&  reqResult.hasOwnProperty("couchdb");
+    console.log("Server information && server running test: ", testResult());
+
+
+
+    // --- createDatabase ---
+    reqResult = await serverManager.createDatabase("testing111222");
+    condition = reqResult;
+    console.log("Created db test: ",testResult());
+
+
+    // --- databaseExist ---
+    reqResult = await serverManager.databaseExist("testing111222");
+    condition = reqResult;
+    console.log("Exist db test: ",testResult());
+
+
+    // --- destroyDatabase ---
+    reqResult = await serverManager.destroyDatabase("testing111222");
+    condition = reqResult;
+    console.log("Destroyed db test: ",testResult());
+
+    if (!await serverManager.databaseExist(DB_NAME))
+      await serverManager.createDatabase(DB_NAME);
+
+    const dbManagerCouchdb = await dbManager.getDatabaseManager(SERVER_URL, DB_NAME);
+
+
+    // --- create View for test docs---
+    let isAlready = true;
+    let viewRes = null;
+    try {
+       viewRes = await dbManagerCouchdb.getDocument("_design/query-demo");
+    }catch(err){
+      isAlready = false;
+    }
+
+    if (!isAlready || viewRes === null) {
+      await dbManagerCouchdb.insertDocument({
+        "_id": "_design/query-demo",
+        "views": {
+          "test": {
+            "map": "function (doc) {  emit([doc.value, doc._id], doc);}"
+          }
+        },
+        "language": "javascript"
+      });
+    }
+
+    console.log("=============Database manager tests============= ");
+    reqResult= await dbManagerCouchdb.getDatabaseInformation();
+    condition = reqResult!=null && reqResult.hasOwnProperty("db_name") && reqResult.db_name === DB_NAME;
+    console.log("Database info test: ", testResult());
+
+
+    console.log("=============Database documents tests============= ");
+
+    // --- Access to nanoConnection object ---
+    reqResult = await dbManagerCouchdb.nanoConnection.info();
+    condition = reqResult!=null && reqResult.hasOwnProperty("db_name") && reqResult.db_name === DB_NAME;
+    console.log("Nano test: ", testResult());
+
+
+    // --- getDesign ---
+    reqResult= await dbManagerCouchdb.getDesign();
+    condition = reqResult!=null && reqResult.hasOwnProperty("rows");
+    console.log("Design test: ", testResult());
+
+
+    // --- insertDocument ---
+    reqResult= await dbManagerCouchdb.insertDocument(TESTING_DOCS[0]);
+    condition = reqResult!=null && reqResult.ok && reqResult.hasOwnProperty("id");
+    console.log("Insert test: ", testResult());
+
+
+
+    // --- deleteDocument ---
+    let toBeDeleted = reqResult.id;
+    reqResult= await dbManagerCouchdb.destroyDocument(toBeDeleted);
+    condition = reqResult!=null && reqResult.ok;
+    console.log("Delete test: ", testResult());
+
+
+    // --- insertDocumentInBulk ---
+    reqResult= await dbManagerCouchdb.insertDocumentInBulk({"docs": TESTING_DOCS});
+    condition = reqResult!=null && Array.isArray(reqResult) && reqResult.length === 4;
+    console.log("Insert bulk test: ", testResult());
+
+
+    // --- getView ---
+    reqResult = await  dbManagerCouchdb.getView("query-demo","test");
+    condition = reqResult!=null && Array.isArray(reqResult.rows) && reqResult.rows.length > 0;
+    console.log("View test: ", testResult());
+
+    let toBeFetched = reqResult.rows.map(el=>el.id);
+    toBeDeleted =  reqResult.rows.map(el=>el.value);
+
+
+    // --- getViewWithQuery ---
+    let queryParams = {startkey:[1], endkey:[1,{}]};
+    reqResult = await  dbManagerCouchdb.getViewWithQuery("" +
+      "query-demo","test", queryParams,true);
+    condition = reqResult!=null && Array.isArray(reqResult.rows) && reqResult.rows.length === 2;
+    console.log("Query test: ", testResult());
+
+    // --- getViewWithQuery and keys---
+    queryParams = {
+      keys : [
+        [1, toBeFetched[0]]
+      ]
+    };
+    reqResult = await  dbManagerCouchdb.getViewWithQuery("" +
+      "query-demo","test", queryParams,true);
+    condition = reqResult!=null && Array.isArray(reqResult.rows) && reqResult.rows.length === 1;
+    console.log("Query with 'keys' test: ", testResult());
+
+
+    // --- fetchDocumentsInBulk ---
+    reqResult= await dbManagerCouchdb.fetchDocumentsInBulk(toBeFetched);
+    condition = reqResult!=null && Array.isArray(reqResult.rows) && reqResult.rows.length >= 4;
+    console.log("Fetch bulk test: ", testResult());
+
+    // --- deleteDocumentInBulk ---
+    reqResult= await dbManagerCouchdb.deleteDocumentInBulk({docs:toBeDeleted});
+    condition = reqResult!=null && Array.isArray(reqResult) && reqResult.length === 4;
+    console.log("Delete bulk test: ", testResult());
+
+  }
+  catch(e){
+    console.log('Error in connection. ERROR:', e);
+    throw e
+  }
+};
+
+//Execute the main process
+main();

--- a/test/testDesign.js
+++ b/test/testDesign.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const SERVER_URL = "http://localhost:5984";
+const DB_NAME = "dbname"; // do not use production DB -  just create a testing one!!!
+
+
+/**
+ * No need to use JEST here! it can be tested with Node process only!
+ *
+ * @returns {boolean} true if the process was executed, false otherwise
+ * @throws {string} if an error occurred during the process
+ */
+const main = async () => {
+
+  let reqResult = null;
+  let condition = null;
+  const testResult = ()=>{
+    if (condition) return "PASSED";
+    return "FAILED";
+  };
+  try {
+    const dbManager = require("../databaseManager");
+    const dbManagerCouchdb = await dbManager.getDatabaseManager(SERVER_URL, DB_NAME);
+
+    // --- getDesign ---
+    reqResult= await dbManagerCouchdb.getDesign();
+    console.log(JSON.stringify(reqResult));
+    condition = reqResult!=null && reqResult.hasOwnProperty("rows");
+    console.log("Design test: ", testResult());
+
+  }
+  catch(e){
+    console.log('Error in connection. ERROR:', e);
+    throw e
+  }
+};
+
+//Execute the main process
+main();


### PR DESCRIPTION
Upgraded nano, removed request-promise-native, added functions (please see What's new in 2.0 in README file).

Please make:  `npm uninstall request-promise-native`  to remove it from `node_modules`, otherwise tests might not work (there is a conflict with new `nano `version).

The equivalents to Couch DB connection (in alphabetical order) couchdb.connection - managerCouchdb :
```
deleteDocumentInBulk - [NEW] deleteDocumentInBulk 
fetchDocuments_CouchDB - [NEW] fetchDocumentsInBulk
getDocument_CouchDB - getDocument(1:1)
getFromView_CouchDB_withQuery - [REMOVED] - no use so far
getView_CouchDB - getView (1:1) 
getView_CouchDB_withQuery - [NEW] getViewWithQuery  (new and modified)
getView_CouchDB_withQuery2 - [REMOVED] - no use
getDesign - [NEW] getDesign 
insertDocument_CouchDB - insertDocument (1:1)
insertDocumentInBulk - insertDocumentInBulk (1:1)
removeDocument_CouchDB - destroyDocument (slightly modified - _rev is optional)
```

Plan for integration to SPINE:
 - remove managerCouchDB and couchdb.connection from SPINE
 - replaced all calls to SPINE version of managerCouchDB and couchdb.connection
  